### PR TITLE
Fix for enhanced lockpicker staying on the door while jamming if an enemy opens it

### DIFF
--- a/EnhancedLockpicker/EnhancedLockpickerComp.cs
+++ b/EnhancedLockpicker/EnhancedLockpickerComp.cs
@@ -58,7 +58,7 @@ namespace EnhancedLockpicker
 
         public void Update()
         {
-            if (isLocking && LP.currentlyPickingDoor != null && LP.currentlyPickingDoor.isLocked)
+            if ((isLocking && LP.currentlyPickingDoor != null && LP.currentlyPickingDoor.isLocked) || (LP.currentlyPickingDoor != null && HarmonyPatches.GetDoorOpened(LP.currentlyPickingDoor)))
             {
                 EnhancedLockpickerNetworkHandler.instance.FinishPickingRpc(this);
             }

--- a/EnhancedLockpicker/HarmonyPatches.cs
+++ b/EnhancedLockpicker/HarmonyPatches.cs
@@ -119,16 +119,30 @@ namespace EnhancedLockpicker
             }
         }
 
+        public static bool GetDoorOpened(DoorLock doorScript)
+        {
+            return (bool)typeof(DoorLock).GetField("isDoorOpened", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(doorScript);
+        }
+
         public static void DL_Update_Postfix(DoorLock __instance)
         {
             if (!__instance.isLocked && __instance.isPickingLock)
             {
+                bool isDoorOpened = GetDoorOpened(__instance);
                 InteractTrigger doorTrigger = (InteractTrigger)DoorTrigger.GetValue(__instance);
                 __instance.lockPickTimeLeft -= Time.deltaTime;
                 doorTrigger.disabledHoverTip = $"Jamming lock: {(int)__instance.lockPickTimeLeft} sec.";
                 if (__instance.lockPickTimeLeft < 0f)
                 {
-                    EnhancedLockpickerNetworkHandler.instance.LockDoorRpc(__instance);
+                    if(!isDoorOpened)
+                    {
+                        EnhancedLockpickerNetworkHandler.instance.LockDoorRpc(__instance);
+                    }
+                    else
+                    {
+                        doorTrigger.interactable = true;
+                        __instance.UnlockDoorServerRpc();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #2 by having the Enhanced Lockpicker check to see if the door is opened while jamming and to fall off the door if it is opened.